### PR TITLE
Remove extra items from Info.plist

### DIFF
--- a/atom-handler.app/Contents/Info.plist
+++ b/atom-handler.app/Contents/Info.plist
@@ -40,20 +40,5 @@
 	</dict>
 	<key>LSRequiresCarbon</key>
 	<true/>
-	<key>WindowState</key>
-	<dict>
-		<key>dividerCollapsed</key>
-		<false/>
-		<key>eventLogLevel</key>
-		<integer>-1</integer>
-		<key>name</key>
-		<string>ScriptWindowState</string>
-		<key>positionOfDivider</key>
-		<real>333</real>
-		<key>savedFrame</key>
-		<string>55 1181 602 597 0 0 2880 1778 </string>
-		<key>selectedTabView</key>
-		<string>result</string>
-	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
You don't have a window, so it doesn't need a saved state.
