### PR TITLE
stop the icon flash in the dock when this is triggered

### DIFF
--- a/atom-handler.app/Contents/Info.plist
+++ b/atom-handler.app/Contents/Info.plist
@@ -55,5 +55,7 @@
 		<key>selectedTabView</key>
 		<string>result</string>
 	</dict>
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
> LSUIElement (String - OS X) specifies whether the app runs as an agent app. If this key is set to “1”, Launch Services runs the app as an agent app. Agent apps do not appear in the Dock or in the Force Quit window. Although they typically run as background apps, they can come to the foreground to present a user interface if desired. A click on a window belonging to an agent app brings that app forward to handle events.
> 
> The Dock and loginwindow are two apps that run as agent apps.

Ref: https://developer.apple.com/library/mac/documentation/general/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html
