### PR TITLE
Add instructions for integration with PHP Xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ if defined? BetterErrors
 end
 ```
 
+## Integrating with PHP Xdebug
+
+Install [Xdebug](http://xdebug.org) for PHP, add the following to your php.ini, and restart your webserver.
+
+```
+xdebug.file_link_format="atm://open?url=file://%f&line=%l"
+```
+
 ## License
 
 Atom Handler is released under the [BSD 3-Clause license](https://github.com/WizardOfOgz/atom-handler/blob/master/LICENSE).


### PR DESCRIPTION
I just switched to atom from sublime and was going to write instructions for the rest of the team for this configuration, but I figured why not put the info where it will help the most people.